### PR TITLE
fix bug where switching from dm to server chan wouldnt receiv msgs

### DIFF
--- a/back-end/src/websocket/channel/get-dm-channels.spec.ts
+++ b/back-end/src/websocket/channel/get-dm-channels.spec.ts
@@ -61,6 +61,7 @@ describe('websocket channel/get-dm-channels', () => {
     const socket = {
       claim: { user_id: user1._id },
       emit: sandbox.spy(),
+      rooms: {},
     };
     const io = {
       of: () => ({

--- a/back-end/src/websocket/channel/get-dm-channels.ts
+++ b/back-end/src/websocket/channel/get-dm-channels.ts
@@ -2,6 +2,7 @@ import { ChannelList } from 'shared-interfaces/channel.interface';
 import Channel from '../../models/channel.model';
 import User from '../../models/user.model';
 import { sendFriendsUserList } from '../friends/send-friends-list';
+import { leaveOtherServers } from '../server/join';
 
 export function getDmChannels(io: any) {
   io.on('connection', socket => {
@@ -18,6 +19,7 @@ export function handler(io, socket) {
       socket.emit('soft-error', 'You are not logged in.');
       return;
     }
+    await leaveOtherServers(socket);
     await Promise.all([
       sendChannelList(user._id, socket),
       sendFriendsUserList(io, socket, user),

--- a/back-end/src/websocket/channel/join.ts
+++ b/back-end/src/websocket/channel/join.ts
@@ -36,12 +36,13 @@ export async function joinChannel(io: any) {
         return;
       }
 
-      // FRIENDS CHANNEL (DM)
+      // FRIENDS DM CHANNEL
       if (channel.getChannelType() === DM_CHANNEL) {
         if (!channel.user_ids.toString().includes(user._id.toString())) {
           socket.emit('soft-error', 'You don\'t have permission to join this channel.');
           return;
         }
+
         socket.join(`dmchannel-${channel._id}`);
       }
 

--- a/back-end/src/websocket/message/send.ts
+++ b/back-end/src/websocket/message/send.ts
@@ -34,16 +34,18 @@ export function sendMessage(io: any) {
           socket.emit('soft-error', 'You are not allowed to send this message.');
           return;
         }
+
         await emitMessage(io, request.message, channel, user, null);
         return;
       }
 
       // NORMAL SERVER
-      const server = await Server.findById(channel.server_id).lean();
+      const server: any = await Server.findById(channel.server_id).lean();
       if (!server || !await canJoinServer(user, channel.server_id)) {
         socket.emit('soft-error', 'You don\'t have permission to send this message.');
         return;
       }
+
       await emitMessage(io, request.message, channel, user, server);
 
       return;

--- a/back-end/src/websocket/server/join.ts
+++ b/back-end/src/websocket/server/join.ts
@@ -60,7 +60,7 @@ async function sendChannelList(socket, serverId) {
 export async function leaveOtherServers(socket) {
   const roomsUserIsIn = Object.keys(socket.rooms);
   for (const room of roomsUserIsIn) {
-    if (room.startsWith('server-') && room !== socket.id) {
+    if (room.startsWith('server-') || room.startsWith('dmchannel-') && room !== socket.id) {
       // Leave any other servers user is in.
       await socket.leave(room);
     }

--- a/src/app/resolvers/main-resolver.service.ts
+++ b/src/app/resolvers/main-resolver.service.ts
@@ -16,7 +16,8 @@ export class MainResolver implements Resolve<any> {
     private store: Store<AppState>,
     private errorService: ErrorService,
     private router: Router,
-  ) { }
+  ) {
+  }
 
   async resolve(route: ActivatedRouteSnapshot, routerState: RouterStateSnapshot): Promise<any> {
     try {


### PR DESCRIPTION
Due to not leaving rooms when going into a dm channel, a situation occured where switching from a dm channel back to a server caused the user's socket to not join the server's channel correctly.

To fix, leave rooms on switching to friends page (on get dm channels endpoint)