### PR TITLE
Make new ChannelListItem interface to be consistent with front-end

### DIFF
--- a/back-end/src/api/channels/get.spec.ts
+++ b/back-end/src/api/channels/get.spec.ts
@@ -77,19 +77,5 @@ describe('api/channels/get', () => {
         expect(response.body).to.have.property('channels');
         expect(response.body.channels).to.have.length(2);
       });
-    // {
-    //   channels: [
-    //     {
-    //       _id: channel1._id.toString(),
-    //       name: 'chantest',
-    //       user_ids: [user1._id.toString(), user2._id.toString()]
-    //     },
-    //     {
-    //       _id: channel2._id.toString(),
-    //       name: 'chantest2',
-    //       user_ids: [user1._id.toString(), user3._id.toString()]
-    //     },
-    //   ],
-    //   }
   });
 });

--- a/back-end/src/models/channel.model.ts
+++ b/back-end/src/models/channel.model.ts
@@ -68,6 +68,7 @@ export function channelsToChannelListItems(channels: any): ChannelListItem[] {
         return {
           _id: chan._id.toString(),
           name: chan.name,
+          user_ids: chan.user_ids,
         };
       }
     });

--- a/back-end/src/models/channel.model.ts
+++ b/back-end/src/models/channel.model.ts
@@ -1,4 +1,5 @@
 import * as mongoose from 'mongoose';
+import { ChannelListItem } from 'shared-interfaces/channel.interface';
 
 const channelSchema = new mongoose.Schema(
   {
@@ -51,3 +52,23 @@ channelSchema.methods.getChannelType = function (): ChannelType {
 const Channel: mongoose.Model<IChannelModel> = mongoose.model<IChannelModel>('Channel', channelSchema);
 
 export default Channel;
+
+export function channelsToChannelListItems(channels: any): ChannelListItem[] {
+  return channels
+    .map(chan => {
+      if (chan.server_id) {
+        // SERVER CHANNEL
+        return {
+          _id: chan._id.toString(),
+          name: chan.name,
+          server_id: chan.server_id.toString(),
+        };
+      } else {
+        // DM CHANNEL (FRIENDS)
+        return {
+          _id: chan._id.toString(),
+          name: chan.name,
+        };
+      }
+    });
+}

--- a/back-end/src/models/channel.model.ts
+++ b/back-end/src/models/channel.model.ts
@@ -55,7 +55,7 @@ export default Channel;
 
 export function channelsToChannelListItems(channels: any): ChannelListItem[] {
   return channels
-    .map(chan => {
+    .map((chan): ChannelListItem => {
       if (chan.server_id) {
         // SERVER CHANNEL
         return {

--- a/back-end/src/websocket/channel/create.spec.ts
+++ b/back-end/src/websocket/channel/create.spec.ts
@@ -2,7 +2,7 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import * as mongoose from 'mongoose';
-import { createChannel } from './create';
+import { createChannel, handler as createChannelHandler } from './create';
 import Channel from '../../models/channel.model';
 import Server from '../../models/server.model';
 import createFakeSocketEvent from '../test_helpers/fake-socket';
@@ -14,6 +14,7 @@ const result = sinon.spy();
 
 describe('websocket channel/create', () => {
   let serverId;
+  const sandbox = sinon.createSandbox();
 
   before(async () => {
     await mongoose.connect('mongodb://localhost/myapp-test');
@@ -32,25 +33,33 @@ describe('websocket channel/create', () => {
     await Server.remove({});
     await Channel.remove({});
     result.resetHistory();
+    sandbox.restore();
   });
-  it('channel/create success', (done) => {
-    const { io, socket } = createFakeSocketEvent('create-channel', {
+  it('channel/create success', async () => {
+    const emit = sandbox.spy();
+    const socket = {
+      claim: {
+        user_id: '123456781234567812345678',
+      },
+      emit,
+    };
+    await createChannelHandler(socket, {
       name: 'channel-name',
       server_id: serverId,
-    }, { user_id: '123456781234567812345678' }, onComplete, result);
-    createChannel(io);
-    function onComplete() {
-      expect(result).to.have.been
-        .calledWith('channel-list',
-        sinon.match({
-          server_id: serverId,
-          channels: [sinon.match({
-            name: 'channel-name',
-            server_id: serverId,
-          })],
-        }));
-      done();
-    }
+    });
+    const channel: any = await Channel.findOne({}).lean();
+
+    expect(channel).not.to.equal(null);
+    expect(channel.name).to.equal('channel-name');
+    expect(socket.emit).to.have.been
+      .calledWith('channel-list', {
+        server_id: serverId,
+        channels: [{
+          _id: channel._id.toString(),
+          name: 'channel-name',
+          server_id: serverId.toString(),
+        }],
+      });
   });
   it('channel/create fails if no server_id given', (done) => {
     const { io, socket } = createFakeSocketEvent('create-channel', {

--- a/back-end/src/websocket/channel/create.ts
+++ b/back-end/src/websocket/channel/create.ts
@@ -1,31 +1,45 @@
 import Server from '../../models/server.model';
-import Channel from '../../models/channel.model';
-import { CreateChannelRequest } from 'shared-interfaces/channel.interface';
+import Channel, { channelsToChannelListItems } from '../../models/channel.model';
+import { CreateChannelRequest, ChannelList, ChannelListItem } from 'shared-interfaces/channel.interface';
 import { log } from 'winston';
 
 export function createChannel(io: any) {
   io.on('connection', socket => {
-    socket.on('create-channel', async (data: CreateChannelRequest) => {
+    socket.on('create-channel', async (channelData: CreateChannelRequest) => {
       try {
-        const server = await Server.findById(data.server_id);
-        if (server.owner_id.toString() !== socket.claim.user_id) {
-          throw new Error('Attempting to create a channel on a server you do not own');
-        }
-        await Channel.create({
-          server_id: server._id,
-          name: data.name,
-        });
-        const channels = await Channel.find({
-          server_id: server._id,
-        }).lean();
-        socket.emit('channel-list', {
-          server_id: server._id,
-          channels: channels,
-        });
+        await handler(socket, channelData);
       } catch (e) {
         log('Error creating server:', e.message);
         socket.emit('soft-error', 'Failed to create channel.');
       }
     });
   });
+}
+
+export async function handler(socket, channelData) {
+  const server = await Server.findById(channelData.server_id);
+
+  if (server.owner_id.toString() !== socket.claim.user_id) {
+    throw new Error('Attempting to create a channel on a server you do not own');
+  }
+  await Channel.create({
+    server_id: server._id,
+    name: channelData.name,
+  });
+  const channels: any = await Channel.find({
+    server_id: server._id,
+  }, {
+      _id: 1,
+      name: 1,
+      server_id: 1,
+    }).lean();
+
+  const channelsFormatted = channelsToChannelListItems(channels);
+
+  const channelList: ChannelList = {
+    server_id: server._id,
+    channels: channelsFormatted,
+  };
+
+  socket.emit('channel-list', channelList);
 }

--- a/back-end/src/websocket/channel/create.ts
+++ b/back-end/src/websocket/channel/create.ts
@@ -1,6 +1,6 @@
 import Server from '../../models/server.model';
 import Channel, { channelsToChannelListItems } from '../../models/channel.model';
-import { CreateChannelRequest, ChannelList, ChannelListItem } from 'shared-interfaces/channel.interface';
+import { CreateChannelRequest, ChannelList } from 'shared-interfaces/channel.interface';
 import { log } from 'winston';
 
 export function createChannel(io: any) {

--- a/back-end/src/websocket/channel/get-dm-channels.spec.ts
+++ b/back-end/src/websocket/channel/get-dm-channels.spec.ts
@@ -81,14 +81,12 @@ describe('websocket channel/get-dm-channels', () => {
       .calledWith('channel-list', {
         channels: [
           {
-            _id: channel1._id,
+            _id: channel1._id.toString(),
             name: 'chantest',
-            user_ids: [user1._id, user2._id],
           },
           {
-            _id: channel2._id,
+            _id: channel2._id.toString(),
             name: 'chantest2',
-            user_ids: [user1._id, user3._id],
           },
         ],
         server_id: 'friends',
@@ -111,14 +109,12 @@ describe('websocket channel/get-dm-channels', () => {
         {
           channels: [
             {
-              _id: channel1._id,
+              _id: channel1._id.toString(),
               name: 'chantest',
-              user_ids: [user1._id, user2._id],
             },
             {
-              _id: channel2._id,
+              _id: channel2._id.toString(),
               name: 'chantest2',
-              user_ids: [user1._id, user3._id],
             },
           ],
           server_id: 'friends',

--- a/back-end/src/websocket/channel/get-dm-channels.spec.ts
+++ b/back-end/src/websocket/channel/get-dm-channels.spec.ts
@@ -83,10 +83,12 @@ describe('websocket channel/get-dm-channels', () => {
           {
             _id: channel1._id.toString(),
             name: 'chantest',
+            user_ids: [user1._id, user2._id],
           },
           {
             _id: channel2._id.toString(),
             name: 'chantest2',
+            user_ids: [user1._id, user3._id],
           },
         ],
         server_id: 'friends',
@@ -111,10 +113,12 @@ describe('websocket channel/get-dm-channels', () => {
             {
               _id: channel1._id.toString(),
               name: 'chantest',
+              user_ids: [user1._id, user2._id],
             },
             {
               _id: channel2._id.toString(),
               name: 'chantest2',
+              user_ids: [user1._id, user3._id],
             },
           ],
           server_id: 'friends',

--- a/back-end/src/websocket/channel/get-dm-channels.ts
+++ b/back-end/src/websocket/channel/get-dm-channels.ts
@@ -1,5 +1,5 @@
-import { ChannelList } from 'shared-interfaces/channel.interface';
-import Channel from '../../models/channel.model';
+import { ChannelList, ChannelListItem } from 'shared-interfaces/channel.interface';
+import Channel, { channelsToChannelListItems } from '../../models/channel.model';
 import User from '../../models/user.model';
 import { sendFriendsUserList } from '../friends/send-friends-list';
 import { leaveOtherServers } from '../server/join';
@@ -33,11 +33,15 @@ export async function sendChannelList(userId, socket) {
       user_ids: userId,
     },
       {
+        _id: 1,
         name: 1,
         user_ids: 1,
+        server_id: 1,
       })
     .sort({ _id: 1 })
     .lean();
+
+  const channelsFormatted = channelsToChannelListItems(channels);
 
   // Get all users in channels for their usernames etc.
   const usersObject = channels.reduce((acc, chan) => {
@@ -58,9 +62,9 @@ export async function sendChannelList(userId, socket) {
     usersObject[user._id] = user;
   });
 
-  const list = <ChannelList>{
+  const list: ChannelList = {
     server_id: 'friends',
-    channels: channels,
+    channels: channelsFormatted,
     users: usersObject,
   };
   socket.emit('channel-list', list);

--- a/back-end/src/websocket/channel/get-dm-channels.ts
+++ b/back-end/src/websocket/channel/get-dm-channels.ts
@@ -1,4 +1,4 @@
-import { ChannelList, ChannelListItem } from 'shared-interfaces/channel.interface';
+import { ChannelList } from 'shared-interfaces/channel.interface';
 import Channel, { channelsToChannelListItems } from '../../models/channel.model';
 import User from '../../models/user.model';
 import { sendFriendsUserList } from '../friends/send-friends-list';

--- a/back-end/src/websocket/channel/join.ts
+++ b/back-end/src/websocket/channel/join.ts
@@ -24,7 +24,7 @@ export async function joinChannel(io: any) {
         return;
       }
 
-      const messages: ChatMessage[] = <ChatMessage[]> await ChatMessageModel
+      const messages: ChatMessage[] = <ChatMessage[]>await ChatMessageModel
         .find({ channel_id: channelId })
         .sort({ createdAt: -1 })
         .limit(50)
@@ -51,6 +51,7 @@ export async function joinChannel(io: any) {
         channel_id: channel._id,
         messages,
       };
+
       socket.emit('joined-channel', response);
     });
   });

--- a/back-end/src/websocket/server/join.spec.ts
+++ b/back-end/src/websocket/server/join.spec.ts
@@ -101,8 +101,8 @@ describe('websocket server/join', () => {
             server_id: server._id,
             channels: [{
               name: channel.name,
-              server_id: server._id,
-              _id: channel._id,
+              server_id: server._id.toString(),
+              _id: channel._id.toString(),
             }],
           });
         expect(socket.join).to.have.been

--- a/back-end/src/websocket/server/join.spec.ts
+++ b/back-end/src/websocket/server/join.spec.ts
@@ -99,11 +99,11 @@ describe('websocket server/join', () => {
         expect(result).to.have.been
           .calledWith('channel-list', {
             server_id: server._id,
-            channels: [sinon.match(item => ({
+            channels: [{
               name: channel.name,
               server_id: server._id,
               _id: channel._id,
-            }))],
+            }],
           });
         expect(socket.join).to.have.been
           .calledWith(`server-${server._id}`);

--- a/back-end/src/websocket/server/join.ts
+++ b/back-end/src/websocket/server/join.ts
@@ -57,7 +57,7 @@ async function sendChannelList(socket, serverId) {
 
   const list: ChannelList = {
     server_id: serverId,
-    channels: channels,
+    channels: channelsFormatted,
   };
 
   socket.emit('channel-list', list);

--- a/back-end/src/websocket/server/join.ts
+++ b/back-end/src/websocket/server/join.ts
@@ -1,5 +1,5 @@
 import Server, { IServerModel } from '../../models/server.model';
-import ChannelModel from '../../models/channel.model';
+import ChannelModel, { channelsToChannelListItems } from '../../models/channel.model';
 import { ChannelList } from 'shared-interfaces/channel.interface';
 import canJoinServer from '../auth/can-join-server';
 import User from '../../models/user.model';
@@ -47,9 +47,15 @@ export function joinServer(io: any) {
 async function sendChannelList(socket, serverId) {
   const channels: any = await ChannelModel.find({
     server_id: serverId,
+  }, {
+    _id: 1,
+    name: 1,
+    server_id: 1,
   }).lean();
 
-  const list = <ChannelList>{
+  const channelsFormatted = channelsToChannelListItems(channels);
+
+  const list: ChannelList = {
     server_id: serverId,
     channels: channels,
   };

--- a/shared-interfaces/channel.interface.d.ts
+++ b/shared-interfaces/channel.interface.d.ts
@@ -8,9 +8,9 @@ export interface CreateChannelRequest {
 export interface ChatChannel {
   _id: string;
   name: string;
-  server_id?: string;
-  user_ids?: string[];
+  server_id?: string;  
   messages?: ChatMessage[];  
+  user_ids?: string[];
 }
 
 export interface ChannelList {

--- a/shared-interfaces/channel.interface.d.ts
+++ b/shared-interfaces/channel.interface.d.ts
@@ -10,13 +10,20 @@ export interface ChatChannel {
   name: string;
   server_id?: string;
   user_ids?: string[];
-  messages?: ChatMessage[];
+  messages?: ChatMessage[];  
 }
 
 export interface ChannelList {
   server_id: string;
-  channels: ChatChannel[];
+  channels: ChannelListItem[];
   users?: any;
+}
+
+export interface ChannelListItem {
+  _id: string;
+  name: string;
+  server_id?: string;
+  has_unread_messages?: boolean;
 }
 
 export interface JoinedChannelResponse {

--- a/shared-interfaces/channel.interface.d.ts
+++ b/shared-interfaces/channel.interface.d.ts
@@ -8,8 +8,8 @@ export interface CreateChannelRequest {
 export interface ChatChannel {
   _id: string;
   name: string;
-  server_id?: string;  
-  messages?: ChatMessage[];  
+  server_id?: string;
+  messages?: ChatMessage[];
   user_ids?: string[];
 }
 
@@ -24,6 +24,7 @@ export interface ChannelListItem {
   name: string;
   server_id?: string;
   has_unread_messages?: boolean;
+  user_ids?: string[];
 }
 
 export interface JoinedChannelResponse {

--- a/src/app/components/channels/channels-list.component.ts
+++ b/src/app/components/channels/channels-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { ChatChannel } from 'shared-interfaces/channel.interface';
+import { ChatChannel, ChannelListItem } from 'shared-interfaces/channel.interface';
 import { WebsocketService } from '../../services/websocket.service';
 import { CreateChannelRequest } from 'shared-interfaces/channel.interface';
 import ChatServer from '../../../../shared-interfaces/server.interface';
@@ -30,7 +30,7 @@ export class ChannelsListComponent implements OnInit {
     return this.currentServer.channelList;
   }
 
-  joinChannel(channel: ChatChannel) {
+  joinChannel(channel: ChannelListItem) {
     this.router.navigate([`channels/${channel.server_id}/${channel._id}`]);
   }
 

--- a/src/app/components/chat-channel/chat-channel.component.html
+++ b/src/app/components/chat-channel/chat-channel.component.html
@@ -18,7 +18,7 @@
     <div *ngIf="!currentChannel.messages"
       class="ui active centered inline loader">
     </div>
-    <div *ngIf="currentChannel.messages && currentChannel.messages.length < 1"
+    <div *ngIf="currentChannel.messages && !currentChannel.messages.length"
       class="ui item">
       <p align="center">
         <i>No messages here yet!</i>

--- a/src/app/components/friends/dmchannel-list/dmchannel-list.component.spec.ts
+++ b/src/app/components/friends/dmchannel-list/dmchannel-list.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
 import { DmchannelListComponent } from './dmchannel-list.component';
-import { ChatChannel, ChannelListItem } from 'shared-interfaces/channel.interface';
+import { ChatChannel } from 'shared-interfaces/channel.interface';
 import ChatServer from 'shared-interfaces/server.interface';
 import { SettingsService } from '../../../services/settings.service';
 
@@ -26,7 +26,7 @@ describe('DmchannelListComponent', () => {
       users: {
         '345': { username: 'user345' },
       },
-      channels: [{ name: channel.name, _id: channel._id, server_id: channel.server_id }],
+      channels: [channel],
     },
   };
 

--- a/src/app/components/friends/dmchannel-list/dmchannel-list.component.spec.ts
+++ b/src/app/components/friends/dmchannel-list/dmchannel-list.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
 import { DmchannelListComponent } from './dmchannel-list.component';
-import { ChatChannel } from 'shared-interfaces/channel.interface';
+import { ChatChannel, ChannelListItem } from 'shared-interfaces/channel.interface';
 import ChatServer from 'shared-interfaces/server.interface';
 import { SettingsService } from '../../../services/settings.service';
 
@@ -26,7 +26,7 @@ describe('DmchannelListComponent', () => {
       users: {
         '345': { username: 'user345' },
       },
-      channels: [channel],
+      channels: [{ name: channel.name, _id: channel._id, server_id: channel.server_id }],
     },
   };
 

--- a/src/app/components/friends/friends.component.spec.ts
+++ b/src/app/components/friends/friends.component.spec.ts
@@ -29,7 +29,7 @@ describe('FriendsComponent', () => {
       users: {
         '345': { username: 'user345' },
       },
-      channels: [channel],
+      channels: [{ name: channel.name, _id: channel._id, server_id: channel.server_id }],
     },
   };
   const friends: FriendsStore = {

--- a/src/app/reducers/current-server-reducer.spec.ts
+++ b/src/app/reducers/current-server-reducer.spec.ts
@@ -3,7 +3,7 @@ import {
   SET_CHANNEL_LIST, SERVER_SET_USER_LIST, SERVER_UPDATE_USER_LIST,
 } from './current-server.reducer';
 import ChatServer, { ServerUserList, UserListUpdate } from 'shared-interfaces/server.interface';
-import { ChannelList } from '../../../shared-interfaces/channel.interface';
+import { ChannelList } from 'shared-interfaces/channel.interface';
 
 describe('reducers/current-server', () => {
   it('JOIN_SERVER', () => {

--- a/src/app/resolvers/chat-channel-resolver.service.ts
+++ b/src/app/resolvers/chat-channel-resolver.service.ts
@@ -10,6 +10,7 @@ import { WebsocketService } from '../services/websocket.service';
 import { Router } from '@angular/router';
 import { ErrorService } from '../services/error.service';
 import 'rxjs/add/operator/map';
+import { ChatChannel, ChannelListItem } from '../../../shared-interfaces/channel.interface';
 
 @Injectable()
 export class ChatChannelResolver implements Resolve<any> {
@@ -29,14 +30,20 @@ export class ChatChannelResolver implements Resolve<any> {
       this.wsService.socket.emit('get-dm-channels', undefined);
     }
 
-    const channel = await this.getChannel(id)
-      .catch(e => {
-        return this.channelNotFound(isOnFriendsPage, route);
-      });
 
-    if (!channel) {
+    let channelListItem: ChannelListItem;
+    try {
+      channelListItem = await this.getChannel(id);
+    } catch (e) {
+      return this.channelNotFound(isOnFriendsPage, route);
+    }
+
+    if (!channelListItem) {
       return;
     }
+
+    const channel: ChatChannel = channelListItem.server_id ? createServerChannel(channelListItem)
+      : createDmChannel(channelListItem);
 
     this.store.dispatch({
       type: LEAVE_CHANNEL,
@@ -55,7 +62,9 @@ export class ChatChannelResolver implements Resolve<any> {
     };
   }
 
-  async getChannel(id: string) {
+
+
+  async getChannel(id: string): Promise<ChannelListItem> {
     const channels = await this.store.select('currentServer')
       .filter(srv => srv && !!srv.channelList)
       .map(srv => srv.channelList.channels)
@@ -79,4 +88,19 @@ export class ChatChannelResolver implements Resolve<any> {
     }
     return false;
   }
+}
+
+function createServerChannel(channelListItem): ChatChannel {
+  return {
+    _id: channelListItem._id,
+    name: channelListItem.name,
+    server_id: channelListItem.server_id,
+  };
+}
+function createDmChannel(channelListItem): ChatChannel {
+  return {
+    _id: channelListItem._id,
+    name: channelListItem.name,
+    user_ids: channelListItem.user_ids,
+  };
 }

--- a/src/app/resolvers/chat-channel-resolver.service.ts
+++ b/src/app/resolvers/chat-channel-resolver.service.ts
@@ -38,12 +38,7 @@ export class ChatChannelResolver implements Resolve<any> {
       return this.channelNotFound(isOnFriendsPage, route);
     }
 
-    if (!channelListItem) {
-      return;
-    }
-
-    const channel: ChatChannel = channelListItem.server_id ? createServerChannel(channelListItem)
-      : createDmChannel(channelListItem);
+    const channel: ChatChannel = createChannel(channelListItem);
 
     this.store.dispatch({
       type: LEAVE_CHANNEL,
@@ -72,6 +67,7 @@ export class ChatChannelResolver implements Resolve<any> {
       .timeout(2500)
       .take(1)
       .toPromise();
+
     return channels.find(chan => chan._id === id);
   }
 
@@ -90,17 +86,20 @@ export class ChatChannelResolver implements Resolve<any> {
   }
 }
 
-function createServerChannel(channelListItem): ChatChannel {
-  return {
-    _id: channelListItem._id,
-    name: channelListItem.name,
-    server_id: channelListItem.server_id,
-  };
-}
-function createDmChannel(channelListItem): ChatChannel {
-  return {
-    _id: channelListItem._id,
-    name: channelListItem.name,
-    user_ids: channelListItem.user_ids,
-  };
+function createChannel(channelListItem): ChatChannel {
+  if (channelListItem.server_id) {
+    // Server channel
+    return {
+      _id: channelListItem._id,
+      name: channelListItem.name,
+      server_id: channelListItem.server_id,
+    };
+  } else {
+    // DM Channel
+    return {
+      _id: channelListItem._id,
+      name: channelListItem.name,
+      user_ids: channelListItem.user_ids,
+    };
+  }
 }


### PR DESCRIPTION
- Seperation of ChannelListItem with ChatChannel (ChatChannel contains extra data such as messages)
- ChannelListItem interface added
- ChannelList interface ammended so channels is of type ChannelListItem[] instead of ChatChannel[].

Difference between ChannelListItem and Channel is that channel contains more properties (user_ids, messages)